### PR TITLE
Fixed xcopy command execute failed in some case.

### DIFF
--- a/FastCopyShellExtension/FastCopyShellExtension.vcxproj
+++ b/FastCopyShellExtension/FastCopyShellExtension.vcxproj
@@ -139,7 +139,7 @@
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy $(SolutionDir)$(Platform)\Release\FastCopy\$(ProjectName).dll $(SolutionDir)$(Platform)\Debug\FastCopy\$(ProjectName).dll /Y</Command>
+      <Command>xcopy "$(SolutionDir)$(Platform)\Release\FastCopy\$(ProjectName).dll" "$(SolutionDir)$(Platform)\Debug\FastCopy\$(ProjectName).dll" /Y /-I</Command>
     </PostBuildEvent>
     <ResourceCompile>
       <ResourceOutputFileName>FastCopyShellExtension.res</ResourceOutputFileName>


### PR DESCRIPTION
Fixed xcopy command execute failed when project path contains ' ', force xcopy detect destination as file when copy dll.