### PR TITLE
Fixed app crashed when first time install.

### DIFF
--- a/FastCopy/SettingsChangeListener.cpp
+++ b/FastCopy/SettingsChangeListener.cpp
@@ -14,8 +14,8 @@ void SettingsChangeListener::BroadcastThemeChange()
 	Settings const settings;
 	ThemeChangeEventArg arg
 	{
-		.theme = settings.Get<int>(Settings::ThemeSelection),
-		.effect = settings.Get<int>(Settings::BackgroundSelection)
+		.theme = settings.Get<int>(Settings::ThemeSelection, 0),
+		.effect = settings.Get<int>(Settings::BackgroundSelection, 0)
 	};
 	do {
 		 findResult = FindWindowEx(HWND_MESSAGE, findResult, MessageWindowClassName, L"");


### PR DESCRIPTION
set default value if settings hadn't the key, which will cause app crashed.