### PR TITLE
Use new injection method of setting process ui language directly inst…

### DIFF
--- a/FastCopy/FastCopy.vcxproj
+++ b/FastCopy/FastCopy.vcxproj
@@ -104,7 +104,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
     <GenerateAppInstallerFile>True</GenerateAppInstallerFile>
-    <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
+    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
@@ -113,7 +113,7 @@
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <AppInstallerUri>E:\</AppInstallerUri>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <PackageCertificateThumbprint>B4DB90FA76002A0C49F3D285A7B0F79A44BC7A9B</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>35E5BA5AF57E50B51C10A6F14CBF580107507F11</PackageCertificateThumbprint>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/FastCopy/Package.appxmanifest
+++ b/FastCopy/Package.appxmanifest
@@ -14,7 +14,7 @@
   <Identity
     Name="HO-COOH.RoboCopyEx"
     Publisher="CN=0000973C-93A8-4716-8C14-5EC442A69DBE"
-    Version="1.1.10.0" />
+    Version="1.2.1.0" />
 
   <Properties>
     <DisplayName>RoboCopyEx</DisplayName>

--- a/FastCopy/RobocopyProcess.cpp
+++ b/FastCopy/RobocopyProcess.cpp
@@ -5,6 +5,13 @@
 #include <wil/resource.h>
 #include "Ntdll.h"
 
+static bool hasEnglishResource()
+{
+	auto path = boost::process::v1::search_path("robocopy.exe").parent_path() / L"en-US" / "robocopy.exe.mui";
+	boost::system::error_code ec;
+	return boost::filesystem::exists(path, ec) && !ec;
+}
+
 void RobocopyProcess::runContext()
 {
 	static bool v = [] {
@@ -33,6 +40,18 @@ JobObject& RobocopyProcess::jobObjectInstance()
 
 void RobocopyProcess::injectProcess()
 {
+	static bool hasEnglishResourceCached = hasEnglishResource();
+	if (!hasEnglishResourceCached)
+	{
+		MessageBox(
+			NULL,
+			L"robocopy.exe does not have English resources. RobocopyEx will not work properly. Please check your Windows installation.",
+			L"RoboCopyEx",
+			MB_ICONERROR
+		);
+		throw InjectionFailed{};
+	}
+
 	auto& path = RobocopyInjectDll::Path();
 	std::wcout << L"Injecting dll: " << path << L'\n';
 	

--- a/FastCopy/RobocopyProcess.h
+++ b/FastCopy/RobocopyProcess.h
@@ -54,6 +54,7 @@ class RobocopyProcess
 	void injectProcess();
 public:
 	struct Exit {};
+	struct InjectionFailed {};
 
 	RobocopyProcess(RobocopyArgsBuilder const& builder, auto callbacks) :
 		m_child
@@ -75,6 +76,10 @@ public:
 		{
 			jobObjectInstance() << Handle();
 			injectProcess();
+		}
+		catch (InjectionFailed const&)
+		{
+
 		}
 		catch (...)
 		{

--- a/FastCopy/SettingsWindow.idl
+++ b/FastCopy/SettingsWindow.idl
@@ -10,5 +10,6 @@ namespace FastCopy
         FastCopy.SettingsViewModel ViewModel{ get; };
         
         static Microsoft.UI.Xaml.Visibility NotToVisibility(Boolean value);
+        static String VersionString{ get; };
     }
 }

--- a/FastCopy/SettingsWindow.xaml
+++ b/FastCopy/SettingsWindow.xaml
@@ -369,16 +369,28 @@
                     Height="16"
                     Margin="8,0,16,0"
                     Source="/Assets/StoreLogo.png" />
-                <TextBlock
-                    x:Name="TitleBarTextBlock"
-                    x:Uid="SettingWindowTitle"
+                <StackPanel
                     Grid.Column="2"
                     VerticalAlignment="Center"
-                    Style="{StaticResource CaptionTextBlockStyle}">
-                    <TextBlock.OpacityTransition>
-                        <ScalarTransition />
-                    </TextBlock.OpacityTransition>
-                </TextBlock>
+                    Orientation="Horizontal"
+                    Spacing="12">
+                    <TextBlock
+                        x:Name="TitleBarTextBlock"
+                        x:Uid="SettingWindowTitle"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}">
+                        <TextBlock.OpacityTransition>
+                            <ScalarTransition />
+                        </TextBlock.OpacityTransition>
+                    </TextBlock>
+
+                    <TextBlock
+                        VerticalAlignment="Bottom"
+                        FontSize="10"
+                        Opacity="0.7"
+                        Text="{x:Bind local:SettingsWindow.VersionString}" />
+                </StackPanel>
+
             </Grid>
 
             <StackPanel Grid.Row="1" Margin="20,12,20,0">

--- a/FastCopy/SettingsWindow.xaml.cpp
+++ b/FastCopy/SettingsWindow.xaml.cpp
@@ -8,6 +8,7 @@
 #include <PackageConfig.h>
 #include "RenameUtils.h"
 #include "TextBlockClipAnimation.h"
+#include <winrt/Windows.ApplicationModel.h>
 
 namespace winrt::FastCopy::implementation
 {
@@ -67,5 +68,10 @@ namespace winrt::FastCopy::implementation
         isRenameSuffixInvalid(!Utils::IsRenameSuffixValid(RenameSuffixTextBox().Text()));
     }
 
+    winrt::hstring SettingsWindow::VersionString()
+    {
+        auto version = winrt::Windows::ApplicationModel::Package::Current().Id().Version();
+        return winrt::hstring{ std::format(L"{}.{}.{}", version.Major, version.Minor, version.Build) };
+    }
 }
 

--- a/FastCopy/SettingsWindow.xaml.h
+++ b/FastCopy/SettingsWindow.xaml.h
@@ -18,6 +18,7 @@ namespace winrt::FastCopy::implementation
                 : winrt::Microsoft::UI::Xaml::Visibility::Visible;
         }
 
+		static winrt::hstring VersionString();
     private:
         void isRenameSuffixInvalid(bool value);
 		bool m_isRenameSuffixInvalid{ false };

--- a/RobocopyInjection/dllmain.cpp
+++ b/RobocopyInjection/dllmain.cpp
@@ -1,137 +1,23 @@
 #include "pch.h"
 #pragma comment(lib, "Dbghelp.lib")
 
-// Configuration: The Language ID we want to force (e.g., en-US)
-constexpr static auto TargetLangId = 0x0409;
+constexpr auto TargetLanguage = L"en-US\0";
 
-// Define the function signatures we are hooking
-using GetUserDefaultLanguageFunc = LANGID(WINAPI*)(void);
-using SetThreadUILanguageFunc = LANGID(WINAPI*)(LANGID);
-using GetThreadUILanguageFunc = LANGID(WINAPI*)(void);
-
-// Pointer to store the original address (optional for IAT, but good practice)
-GetUserDefaultLanguageFunc pOriginalGetUserDefaultUILanguage{};
-SetThreadUILanguageFunc pOriginalSetThreadUILanguage{};
-GetThreadUILanguageFunc pOriginalGetThreadUILanguage{};
-
-// ---------------------------------------------------------
-// 1. The Fake Function
-// ---------------------------------------------------------
-LANGID WINAPI Fake_GetUserDefaultUILanguage(void) 
+static bool ForceEnglish()
 {
-    return TargetLangId;
+    ULONG numLanguages{};
+	auto const processOK = SetProcessPreferredUILanguages(MUI_LANGUAGE_NAME, TargetLanguage, &numLanguages);
+
+    SetThreadPreferredUILanguages(MUI_LANGUAGE_NAME, TargetLanguage, nullptr);
+	return processOK && numLanguages > 0;
 }
 
-LANGID WINAPI Fake_SetThreadUILanguage(LANGID LangId) 
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved) 
 {
-    return TargetLangId;
-}
-
-LANGID WINAPI Fake_GetThreadUILanguage(void) 
-{
-    return TargetLangId;
-}
-
-// ---------------------------------------------------------
-// 2. The IAT Hooking Logic
-// ---------------------------------------------------------
-void InstallIATHook(const char* dllName, const char* funcName, void* newFuncAddress, void** ppOriginalAddress) {
-    // Get the base address of the current process (the target EXE)
-    HMODULE hModule = GetModuleHandle(NULL);
-
-    ULONG size;
-    // Locate the Import Directory in the PE Headers
-    PIMAGE_IMPORT_DESCRIPTOR pImportDesc = (PIMAGE_IMPORT_DESCRIPTOR)ImageDirectoryEntryToData(
-        hModule, TRUE, IMAGE_DIRECTORY_ENTRY_IMPORT, &size);
-
-    if (!pImportDesc) return; // No imports found
-
-    // Loop through all imported DLLs to find the one we want (e.g., "kernel32.dll")
-    while (pImportDesc->Name) {
-        const char* moduleName = (char*)((BYTE*)hModule + pImportDesc->Name);
-
-        // Check if the module name matches (case insensitive)
-        if (_stricmp(moduleName, dllName) == 0) {
-            // Found the DLL. Now loop through its functions.
-
-            // OriginalFirstThunk points to the function NAMES
-            PIMAGE_THUNK_DATA pThunkName = (PIMAGE_THUNK_DATA)((BYTE*)hModule + pImportDesc->OriginalFirstThunk);
-            // FirstThunk points to the function ADDRESSES (The IAT)
-            PIMAGE_THUNK_DATA pThunkAddr = (PIMAGE_THUNK_DATA)((BYTE*)hModule + pImportDesc->FirstThunk);
-
-            // Some compilers might not produce OriginalFirstThunk. If so, use FirstThunk (which points to names before binding)
-            if (!pThunkName) {
-                pThunkName = pThunkAddr;
-            }
-
-            while (pThunkName && pThunkName->u1.Function) {
-                // Check if imported by Name (not by Ordinal)
-                if (!(pThunkName->u1.Ordinal & IMAGE_ORDINAL_FLAG)) {
-                    PIMAGE_IMPORT_BY_NAME pImportName = (PIMAGE_IMPORT_BY_NAME)((BYTE*)hModule + pThunkName->u1.AddressOfData);
-
-                    // Check if this is the function we are looking for
-                    if (strcmp(pImportName->Name, funcName) == 0) {
-
-                        // FOUND IT! Now we overwrite the address.
-
-                        // 1. Make the memory writable (IAT is usually Read-Only)
-                        DWORD oldProtect;
-                        VirtualProtect(&pThunkAddr->u1.Function, sizeof(uintptr_t), PAGE_READWRITE, &oldProtect);
-
-                        // 2. Save original (optional)
-                        if (ppOriginalAddress && *ppOriginalAddress == NULL) {
-                            *ppOriginalAddress = (void*)pThunkAddr->u1.Function;
-                        }
-
-                        // 3. Overwrite with our function address
-                        pThunkAddr->u1.Function = (uintptr_t)newFuncAddress;
-
-                        // 4. Restore memory protections
-                        VirtualProtect(&pThunkAddr->u1.Function, sizeof(uintptr_t), oldProtect, &oldProtect);
-                        
-                        return; // Hook installed, we are done.
-                    }
-                }
-                pThunkName++;
-                pThunkAddr++;
-            }
-        }
-        pImportDesc++;
-    }
-}
-
-// ---------------------------------------------------------
-// 3. Entry Point
-// ---------------------------------------------------------
-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved) {
-    if (ul_reason_for_call == DLL_PROCESS_ATTACH) {
+    if (ul_reason_for_call == DLL_PROCESS_ATTACH)
+    {
         DisableThreadLibraryCalls(hModule);
-
-        // Force thread language immediately using the actual API (if available)
-        HMODULE hKernel = GetModuleHandleA("kernel32.dll");
-        if (hKernel) {
-             SetThreadUILanguageFunc pSet = (SetThreadUILanguageFunc)GetProcAddress(hKernel, "SetThreadUILanguage");
-             if (pSet) {
-                 pSet(TargetLangId);
-             }
-        }
-
-        // Hook GetUserDefaultUILanguage inside kernel32.dll
-        InstallIATHook("kernel32.dll", "GetUserDefaultUILanguage", Fake_GetUserDefaultUILanguage, (void**)&pOriginalGetUserDefaultUILanguage);
-        InstallIATHook("kernelbase.dll", "GetUserDefaultUILanguage", Fake_GetUserDefaultUILanguage, NULL);
-
-        // Often apps call GetSystemDefaultUILanguage as fallback, hook that too
-        InstallIATHook("kernel32.dll", "GetSystemDefaultUILanguage", Fake_GetUserDefaultUILanguage, NULL);
-        InstallIATHook("kernelbase.dll", "GetSystemDefaultUILanguage", Fake_GetUserDefaultUILanguage, NULL);
-
-        // Hook SetThreadUILanguage to force en-US
-        InstallIATHook("kernel32.dll", "SetThreadUILanguage", Fake_SetThreadUILanguage, (void**)&pOriginalSetThreadUILanguage);
-        InstallIATHook("kernelbase.dll", "SetThreadUILanguage", Fake_SetThreadUILanguage, NULL);
-
-        // Hook GetThreadUILanguage
-        InstallIATHook("kernel32.dll", "GetThreadUILanguage", Fake_GetThreadUILanguage, (void**)&pOriginalGetThreadUILanguage);
-        InstallIATHook("kernelbase.dll", "GetThreadUILanguage", Fake_GetThreadUILanguage, NULL);
+        ForceEnglish();
     }
     return TRUE;
 }
-


### PR DESCRIPTION
…ead of hooking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core robocopy startup/injection and English-output assumptions; missing MUI now blocks injection, and the new MUI approach may behave differently than IAT hooks on some Windows builds.
> 
> **Overview**
> **Robocopy injection** no longer patches `robocopy.exe` imports. The injected DLL now calls `SetProcessPreferredUILanguages` / `SetThreadPreferredUILanguages` for **en-US** on attach, replacing the previous IAT hooks on UI-language APIs in `kernel32` / `kernelbase`.
> 
> Before injecting, the host checks that `en-US\robocopy.exe.mui` exists next to `robocopy.exe`. If it is missing, it shows an error and throws `InjectionFailed`, which is handled without the generic “injection failed” dialog.
> 
> The **settings** title bar shows the package version (`major.minor.build`) from `Package::Current()`.
> 
> **Release packaging**: app version **1.2.1.0**, MSIX signing enabled, and an updated package certificate thumbprint in the project file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19828a4f99e68918d7aac655fc9f320ab19fc25d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->