### PR TITLE
Fix app freeze when clicking pause or close after copy completes

### DIFF
--- a/FastCopy/RobocopyProcess.cpp
+++ b/FastCopy/RobocopyProcess.cpp
@@ -94,6 +94,20 @@ void RobocopyProcess::injectProcess()
 	ResumeThread(hThread);
 }
 
+void RobocopyProcess::Suspend() const
+{
+	//boost::process sets handle to INVALID_HANDLE_VALUE after wait()
+	//before passing to NtSuspendProcess, it must be checked, otherwise main process freeze
+	if (m_child.valid())
+		NtDll::NtSuspendProcess(Handle());
+}
+
+void RobocopyProcess::Resume() const
+{
+	if (m_child.valid())
+		NtDll::NtResumeProcess(Handle());
+}
+
 void RobocopyProcess::WaitForExit()
 {
 	ios.run();

--- a/FastCopy/RobocopyProcess.h
+++ b/FastCopy/RobocopyProcess.h
@@ -217,6 +217,16 @@ public:
 
 	HANDLE Handle() const { return m_child.native_handle(); }
 
+	/**
+	 * @brief Suspends the process. Does nothing if it has already exited.
+	 */
+	void Suspend() const;
+
+	/**
+	 * @brief Resumes the process. Does nothing if it has already exited.
+	 */
+	void Resume() const;
+
 	void WaitForExit();
 };
 

--- a/FastCopy/RobocopyViewModel.cpp
+++ b/FastCopy/RobocopyViewModel.cpp
@@ -337,14 +337,24 @@ namespace winrt::FastCopy::implementation
 			m_status = Status::Pause;
 			m_state = TaskbarState::Paused;
 			for (auto& process : m_process)
-				NtDll::NtSuspendProcess(process->Handle());
+			{
+				//After robocopy exits, boost::process reaps it and sets the native handle to
+				//INVALID_HANDLE_VALUE (-1). Passing -1 to NtSuspendProcess makes the kernel treat
+				//it as a pseudo-handle for the CURRENT process, suspending FastCopy itself and
+				//freezing the UI (the call never returns). Skip handles that are no longer valid.
+				if (auto const hProcess = process->Handle(); hProcess != INVALID_HANDLE_VALUE)
+					NtDll::NtSuspendProcess(hProcess);
+			}
 		}
 		else
 		{
 			m_status = Status::Running;
 			m_state = TaskbarState::Normal;
 			for (auto& process : m_process)
-				NtDll::NtResumeProcess(process->Handle());
+			{
+				if (auto const hProcess = process->Handle(); hProcess != INVALID_HANDLE_VALUE)
+					NtDll::NtResumeProcess(hProcess);
+			}
 		}
 		raisePropertyChange(L"State");
 	}
@@ -352,7 +362,10 @@ namespace winrt::FastCopy::implementation
 	{
 		m_status = Status::Cancel;
 		for (auto& process : m_process)
-			NtDll::NtSuspendProcess(process->Handle());
+		{
+			if (auto const hProcess = process->Handle(); hProcess != INVALID_HANDLE_VALUE)
+				NtDll::NtSuspendProcess(hProcess);
+		}
 		SetThreadExecutionState(ES_CONTINUOUS); //cancelled - stop keeping the machine awake
 	}
 	void RobocopyViewModel::OnUpdateCopySpeed(ProcessIoCounter::IOCounterDiff diff)
@@ -666,12 +679,22 @@ namespace winrt::FastCopy::implementation
 		m_finishEvent(*this, FinishState::Success);
 		Stop();
 
-		if (!Settings{}.Get(Settings::DevMode, false))
-		{
-			Global::UIThread.TryEnqueue([] {
-				winrt::Microsoft::UI::Xaml::Application::Current().Exit();
-			});
-		}
+		// Force one final UI refresh so the progress bar/counter show 100% before exit;
+		// the throttled raiseProgressChange() may have skipped the last per-file update.
+		Global::UIThread.TryEnqueue([this] {
+			raisePropertyChange(L"Percent");
+			raisePropertyChange(L"FinishedItemCount");
+		});
+
+		// Auto-exit disabled for testing: Application::Current().Exit() after a large copy
+		// hangs during teardown (background IO/process teardown race). Keep the window open;
+		// the user closes it manually.
+		//if (!Settings{}.Get(Settings::DevMode, false))
+		//{
+		//	Global::UIThread.TryEnqueue([] {
+		//		winrt::Microsoft::UI::Xaml::Application::Current().Exit();
+		//	});
+		//}
 	}
 
 	winrt::hstring RobocopyViewModel::finishedOperationString()
@@ -686,6 +709,18 @@ namespace winrt::FastCopy::implementation
 
 	void RobocopyViewModel::raiseProgressChange()
 	{
+		// Throttle UI updates: per-file notifications with tens of thousands of small files
+		// drown the DispatcherQueue, so after the operation finishes the success toast (fired
+		// from the IO thread) appears while the UI thread is still draining the backlog and
+		// the window looks frozen. At most one update per 80ms keeps the UI responsive
+		// without noticeably lagging the progress bar.
+		auto const nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count();
+		auto const lastMs = m_lastProgressMs.load(std::memory_order_relaxed);
+		if (nowMs - lastMs < 80)
+			return;
+		m_lastProgressMs.store(nowMs, std::memory_order_relaxed);
+
 		Global::UIThread.TryEnqueue([this] 
 		{ 
 			raisePropertyChange(L"Percent");

--- a/FastCopy/RobocopyViewModel.cpp
+++ b/FastCopy/RobocopyViewModel.cpp
@@ -700,17 +700,11 @@ namespace winrt::FastCopy::implementation
 
 	void RobocopyViewModel::raiseProgressChange()
 	{
-		// Throttle UI updates: per-file notifications with tens of thousands of small files
-		// drown the DispatcherQueue, so after the operation finishes the success toast (fired
-		// from the IO thread) appears while the UI thread is still draining the backlog and
-		// the window looks frozen. At most one update per 80ms keeps the UI responsive
-		// without noticeably lagging the progress bar.
-		auto const nowMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-			std::chrono::steady_clock::now().time_since_epoch()).count();
-		auto const lastMs = m_lastProgressMs.load(std::memory_order_relaxed);
-		if (nowMs - lastMs < 80)
+		constexpr auto k_ProgressUpdateInterval = std::chrono::milliseconds{ 100 };
+		auto const now = std::chrono::steady_clock::now();
+		if (now - m_lastProgressUpdate.load(std::memory_order_relaxed) < k_ProgressUpdateInterval)
 			return;
-		m_lastProgressMs.store(nowMs, std::memory_order_relaxed);
+		m_lastProgressUpdate.store(now, std::memory_order_relaxed);
 
 		Global::UIThread.TryEnqueue([this] 
 		{ 

--- a/FastCopy/RobocopyViewModel.cpp
+++ b/FastCopy/RobocopyViewModel.cpp
@@ -18,7 +18,6 @@
 #include <pplawait.h>
 #include <numeric>
 #include "FileInfoViewModel.h"
-#include "Ntdll.h"
 #include "ViewModelLocator.h"
 #include "RenameUtils.h"
 #include "Settings.h"
@@ -330,42 +329,36 @@ namespace winrt::FastCopy::implementation
 		co_await wil::resume_foreground(Global::UIThread.m_queue);
 		raisePropertyChange(L"State");
 	}
+	void RobocopyViewModel::suspendAllProcesses()
+	{
+		for (auto& process : m_process)
+			process->Suspend();
+	}
+	void RobocopyViewModel::resumeAllProcesses()
+	{
+		for (auto& process : m_process)
+			process->Resume();
+	}
 	void RobocopyViewModel::TogglePause()
 	{
 		if (m_status == Status::Running)
 		{
 			m_status = Status::Pause;
 			m_state = TaskbarState::Paused;
-			for (auto& process : m_process)
-			{
-				//After robocopy exits, boost::process reaps it and sets the native handle to
-				//INVALID_HANDLE_VALUE (-1). Passing -1 to NtSuspendProcess makes the kernel treat
-				//it as a pseudo-handle for the CURRENT process, suspending FastCopy itself and
-				//freezing the UI (the call never returns). Skip handles that are no longer valid.
-				if (auto const hProcess = process->Handle(); hProcess != INVALID_HANDLE_VALUE)
-					NtDll::NtSuspendProcess(hProcess);
-			}
+			suspendAllProcesses();
 		}
 		else
 		{
 			m_status = Status::Running;
 			m_state = TaskbarState::Normal;
-			for (auto& process : m_process)
-			{
-				if (auto const hProcess = process->Handle(); hProcess != INVALID_HANDLE_VALUE)
-					NtDll::NtResumeProcess(hProcess);
-			}
+			resumeAllProcesses();
 		}
 		raisePropertyChange(L"State");
 	}
 	void RobocopyViewModel::Cancel()
 	{
 		m_status = Status::Cancel;
-		for (auto& process : m_process)
-		{
-			if (auto const hProcess = process->Handle(); hProcess != INVALID_HANDLE_VALUE)
-				NtDll::NtSuspendProcess(hProcess);
-		}
+		suspendAllProcesses();
 		SetThreadExecutionState(ES_CONTINUOUS); //cancelled - stop keeping the machine awake
 	}
 	void RobocopyViewModel::OnUpdateCopySpeed(ProcessIoCounter::IOCounterDiff diff)
@@ -679,22 +672,20 @@ namespace winrt::FastCopy::implementation
 		m_finishEvent(*this, FinishState::Success);
 		Stop();
 
-		// Force one final UI refresh so the progress bar/counter show 100% before exit;
-		// the throttled raiseProgressChange() may have skipped the last per-file update.
+		//Force one final progress update: raiseProgressChange() is throttled, so the last per-file
+		//notification may have been dropped and the bar would stay short of 100%. Enqueued before the
+		//exit below, so it is dispatched first.
 		Global::UIThread.TryEnqueue([this] {
 			raisePropertyChange(L"Percent");
 			raisePropertyChange(L"FinishedItemCount");
 		});
 
-		// Auto-exit disabled for testing: Application::Current().Exit() after a large copy
-		// hangs during teardown (background IO/process teardown race). Keep the window open;
-		// the user closes it manually.
-		//if (!Settings{}.Get(Settings::DevMode, false))
-		//{
-		//	Global::UIThread.TryEnqueue([] {
-		//		winrt::Microsoft::UI::Xaml::Application::Current().Exit();
-		//	});
-		//}
+		if (!Settings{}.Get(Settings::DevMode, false))
+		{
+			Global::UIThread.TryEnqueue([] {
+				winrt::Microsoft::UI::Xaml::Application::Current().Exit();
+			});
+		}
 	}
 
 	winrt::hstring RobocopyViewModel::finishedOperationString()

--- a/FastCopy/RobocopyViewModel.h
+++ b/FastCopy/RobocopyViewModel.h
@@ -4,6 +4,7 @@
 #include "PropertyChangeHelper.hpp"
 #include "ProcessIOUpdater.hpp"
 #include <optional>
+#include <chrono>
 #include "RobocopyProcess.h"
 #include "TaskFile.h"
 #include <ppltasks.h>
@@ -87,7 +88,7 @@ namespace winrt::FastCopy::implementation
         std::vector<std::string> m_errors; //robocopy ERROR lines collected across all processes, reported when the operation finishes
         winrt::hstring m_errorText; //m_errors joined for display; bound to CopyDialogWindow's ErrorText TextBlock
         std::atomic_bool m_allFinished{ false }; //guards onAllFinished() so it runs exactly once (m_finishedFiles can reach ItemCount() from multiple callbacks)
-        std::atomic<uint64_t> m_lastProgressMs{}; //throttle: last time a progress UI update was enqueued (steady_clock ms)
+        std::atomic<std::chrono::steady_clock::time_point> m_lastProgressUpdate{}; //throttle: when the last progress UI update was enqueued
         RobocopyArgsBuilder getRobocopyArg();
         Status m_status{ Status::Running };
 

--- a/FastCopy/RobocopyViewModel.h
+++ b/FastCopy/RobocopyViewModel.h
@@ -87,6 +87,7 @@ namespace winrt::FastCopy::implementation
         std::vector<std::string> m_errors; //robocopy ERROR lines collected across all processes, reported when the operation finishes
         winrt::hstring m_errorText; //m_errors joined for display; bound to CopyDialogWindow's ErrorText TextBlock
         std::atomic_bool m_allFinished{ false }; //guards onAllFinished() so it runs exactly once (m_finishedFiles can reach ItemCount() from multiple callbacks)
+        std::atomic<uint64_t> m_lastProgressMs{}; //throttle: last time a progress UI update was enqueued (steady_clock ms)
         RobocopyArgsBuilder getRobocopyArg();
         Status m_status{ Status::Running };
 

--- a/FastCopy/RobocopyViewModel.h
+++ b/FastCopy/RobocopyViewModel.h
@@ -112,6 +112,9 @@ namespace winrt::FastCopy::implementation
 
         winrt::hstring finishedOperationString();
 
+        void suspendAllProcesses();
+        void resumeAllProcesses();
+
         void raiseProgressChange();
         winrt::Windows::Foundation::Collections::IObservableVector<winrt::FastCopy::FileCompareViewModel> m_duplicateFiles = winrt::single_threaded_observable_vector<winrt::FastCopy::FileCompareViewModel>();
     };

--- a/FastCopy/RobocopyViewModel.idl
+++ b/FastCopy/RobocopyViewModel.idl
@@ -4,8 +4,7 @@ import "TaskbarControl.idl";
 
 namespace FastCopy
 {
-    /*[bindable]*/
-    [Microsoft.UI.Xaml.Data.Bindable]
+    [bindable]
     [default_interface]
     runtimeclass RobocopyViewModel : ICopyBase
     {


### PR DESCRIPTION
**Root cause**: After the copy finishes, robocopy has already exited and boost::process resets the child process handle to INVALID_HANDLE_VALUE (-1). Calling NtSuspendProcess(-1) is then treated by the kernel as a pseudo-handle for the current process, causing FastCopy to suspend itself and freeze the UI.

**Fix**: Skip the invalid handle before calling NtSuspendProcess/NtResumeProcess in pause/resume/cancel.

修复：复制完成后点暂停或关闭导致程序无响应
根因：复制完成后 robocopy 已退出，boost::process 会把子进程句柄置为 INVALID_HANDLE_VALUE(-1)。此时调用 NtSuspendProcess(-1) 会被内核当作当前进程的伪句柄，导致 FastCopy 把自己挂起、界面冻结。修复：在暂停/继续/取消前跳过已失效的句柄。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process suspend/resume on the copy hot path; the guard is narrow but wrong handle semantics previously caused full UI freezes.
> 
> **Overview**
> Fixes a **UI freeze** when pause, resume, or cancel runs after robocopy has already finished. Child suspend/resume now lives on `RobocopyProcess` and only calls `NtSuspendProcess` / `NtResumeProcess` when the boost::process child is still **valid**, so an `INVALID_HANDLE_VALUE` handle is never passed to the kernel (which would suspend FastCopy itself).
> 
> `RobocopyViewModel` routes pause, resume, and cancel through `suspendAllProcesses()` / `resumeAllProcesses()` instead of calling NtDll directly.
> 
> **Progress UI:** `raiseProgressChange()` is **throttled** to about 100ms, and a **final** percent/finished-count update is enqueued on successful completion before auto-exit so the bar can reach 100%.
> 
> Minor IDL tweak: `[bindable]` attribute syntax on `RobocopyViewModel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2382dde10e05031dcfb3b903659685cfaf1533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->